### PR TITLE
Remove tarball documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ Test
 
     mix test
 
-To build distributable tarball
-
-    mix ex2js.dist
-
-    `ex2js.tar.gz` will be in the `dist` folder
 
 Usage
 ===


### PR DESCRIPTION
Removes a portion of the README that is not relevant to the current distributed codebase.  After cloning, building a tarball with mix is not something you can do.