### PR TITLE
Added stdlib_path option to compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * Added ElixirScript.Html module for defining a virtual-dom tree
   * Added ElixirScript.VDom module for manipulating the virtual-dom tree created
   using the ElixirScript.Html module
+  * Added `stdlib_path` compiler option to specify the es6 path to the standard library.
+  If used, elixir.js will not be exported with the compiled modules
 
 
 # v0.13.0

--- a/lib/elixir_script/cli.ex
+++ b/lib/elixir_script/cli.ex
@@ -3,11 +3,11 @@ defmodule ElixirScript.CLI do
 
   @switches [
     output: :binary, elixir: :boolean, root: :binary,
-    help: :boolean, stdlib: :boolean
+    help: :boolean, stdlib: :boolean, stdlib_path: :binary
   ]
 
   @aliases [
-    o: :output, ex: :elixir, h: :help, r: :root, st: :stdlib
+    o: :output, ex: :elixir, h: :help, r: :root, st: :stdlib, stp: :stdlib_path
   ]
 
   def main(argv) do
@@ -23,7 +23,7 @@ defmodule ElixirScript.CLI do
       { [help: true] , _ , _ } -> :help
       { [stdlib: true] , _ , _ } -> :stdlib
       { options , [input], _ } -> { input, options }
-      { [], [], [] } -> :help
+      _ -> :help
     end
 
   end
@@ -36,8 +36,10 @@ defmodule ElixirScript.CLI do
       options:
       -o  --output [path]   places output at the given path
       -ex --elixir          read input as elixir code string
-      -r  --root [path]     root path for standard libs
+      -r  --root [path]     root import path for all exported modules
       -st  --stdlib         outputs the standard lib js file
+      -stp --stdlib_path    es6 import path to the elixirscript standard lib
+      only used with the [output] option. When used, elixir.js is not exported
       -h  --help            this message
     """
   end
@@ -57,7 +59,8 @@ defmodule ElixirScript.CLI do
   def do_process(input, options) do
     compile_opts = [
       root: options[:root],
-      include_path: options[:output] != nil
+      include_path: options[:output] != nil,
+      stdlib_path: Dict.get(options, :stdlib_path, "elixir")
     ]
 
     compile_output = case options[:elixir] do
@@ -79,7 +82,9 @@ defmodule ElixirScript.CLI do
           write_to_file(x, output_path)
         end)
 
-        ElixirScript.copy_standard_libs_to_destination(output_path)
+        if Dict.get(options, :stdlib_path) == nil do
+          ElixirScript.copy_standard_libs_to_destination(output_path)
+        end
     end
   end
 

--- a/lib/elixir_script/translator/import.ex
+++ b/lib/elixir_script/translator/import.ex
@@ -159,7 +159,7 @@ defmodule ElixirScript.Translator.Import do
 
   defp make_source(name) do
     root = ElixirScript.State.get().root
-    "'#{root(root)}#{make_file_path(name)}'"
+    "'#{make_root(root)}#{make_file_path(name)}'"
   end
 
   def make_file_path(name) do
@@ -180,24 +180,25 @@ defmodule ElixirScript.Translator.Import do
     Set.difference(Enum.into(functions, HashSet.new), Enum.into(except, HashSet.new))
   end
 
-  def create_standard_lib_imports(root, _) do
+  def create_standard_lib_imports(root, name) do
+
     import_specifier = JS.import_namespace_specifier(
       JS.identifier(:Elixir)
     )
 
     import_declaration = JS.import_declaration(
       [import_specifier],
-      JS.identifier("'#{root(root) <> "elixir"}'")
+      JS.identifier("'#{make_root(root) <> name}'")
     )
 
     [import_declaration]
   end
 
-  defp root(nil) do
+  defp make_root(nil) do
     ""
   end
 
-  defp root(root) do
+  defp make_root(root) do
     root <> "/"
   end
 

--- a/lib/mix/tasks/elixirscript.ex
+++ b/lib/mix/tasks/elixirscript.ex
@@ -7,7 +7,10 @@ defmodule Mix.Tasks.Elixirscript do
       options:
       -o  --output [path]   places output at the given path
       -ex --elixir          read input as elixir code string
-      -r  --root [path]     root path for standard libs
+      -r  --root [path]     root import path for all exported modules
+      -st  --stdlib         outputs the standard lib js file
+      -stp --stdlib_path    es6 import path to the elixirscript standard lib
+      only used with the [output] option. When used, elixir.js is not exported
       -h  --help            this message
   """
 

--- a/test/elixir_script_test.exs
+++ b/test/elixir_script_test.exs
@@ -141,4 +141,33 @@ defmodule ElixirScript.Test do
       assert hd(js_code) =~ "Elixir.VirtualDOM.create"
   end
 
+
+  should "set standard lib path" do
+
+    js_code = ElixirScript.compile("""
+      defmodule Animals do
+        use ElixirScript.Using
+
+        defp something_else() do
+          ElixirScript.Math.squared(1)
+        end
+
+      end
+    """, env: make_custom_env, stdlib_path: "elixirscript")
+
+    assert_js_matches """
+         import * as Elixir from 'elixirscript';
+         const __MODULE__ = Elixir.Kernel.SpecialForms.atom('Animals');
+         const something_else = Elixir.Patterns.defmatch(Elixir.Patterns.make_case([],function()    {
+             return     1 * 1;
+           }));
+         const sandwich = Elixir.Patterns.defmatch(Elixir.Patterns.make_case([],function()    {
+             return     null;
+           }));
+         export {
+             sandwich
+       };
+     """, hd(js_code)
+  end
+
 end


### PR DESCRIPTION
#125

Added `stdlib_path` compiler option to specify the es6 path to the standard library.
  If used, elixir.js will not be exported with the compiled modules